### PR TITLE
refactor(core): separate UI from monitor utility logic

### DIFF
--- a/ReSize.vcxproj
+++ b/ReSize.vcxproj
@@ -104,6 +104,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(ProjectDir)include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -127,12 +128,14 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="main.cpp" />
-    <ClCompile Include="MonitorUtils.cpp" />
+    <ClCompile Include="src/main.cpp" />
+    <ClCompile Include="src/MonitorUtils.cpp" />
+    <ClCompile Include="src\ConsoleUI.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="MonitorInfo.h" />
-    <ClInclude Include="MonitorUtils.h" />
+    <ClInclude Include="include/MonitorInfo.h" />
+    <ClInclude Include="include/MonitorUtils.h" />
+    <ClInclude Include="include\ConsoleUI.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/ReSize.vcxproj.filters
+++ b/ReSize.vcxproj.filters
@@ -15,18 +15,18 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="main.cpp">
+    <ClCompile Include="src/main.cpp">
       <Filter>Arquivos de Origem</Filter>
     </ClCompile>
-    <ClCompile Include="MonitorUtils.cpp">
+    <ClCompile Include="src/MonitorUtils.cpp">
       <Filter>Arquivos de Origem</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="MonitorInfo.h">
+    <ClInclude Include="include/MonitorInfo.h">
       <Filter>Arquivos de Cabeçalho</Filter>
     </ClInclude>
-    <ClInclude Include="MonitorUtils.h">
+    <ClInclude Include="include/MonitorUtils.h">
       <Filter>Arquivos de Cabeçalho</Filter>
     </ClInclude>
   </ItemGroup>

--- a/include/ConsoleUI.h
+++ b/include/ConsoleUI.h
@@ -1,0 +1,19 @@
+#ifndef CONSOLEUI_H
+#define CONSOLEUI_H
+
+#include "MonitorUtils.h" // Precisa de MonitorInfo e MonitorStatus
+#include <string>
+#include <vector>
+
+namespace ConsoleUI {
+
+    void setupConsole();
+    void printMonitorInfo(const std::vector<MonitorInfo>& monitors);
+    int displayMainMenu();
+    int selectMonitor(const std::vector<MonitorInfo>& monitors);
+    void showOperationResult(MonitorStatus status);
+    void waitAndClear();
+
+} // namespace ConsoleUI
+
+#endif // CONSOLEUI_H

--- a/include/MonitorUtils.h
+++ b/include/MonitorUtils.h
@@ -1,15 +1,31 @@
 #ifndef MONITORUTILS_H
 #define MONITORUTILS_H
 
-#include "monitorinfo.h"
 #include <string>
 #include <vector>
+#include <windows.h> // Para DWORD
 
-using namespace std;
+// Estrutura para manter as informações de um monitor
+struct MonitorInfo {
+    std::wstring deviceName;
+    int width;
+    int height;
+    bool isPrimary;
+    DWORD stateFlags;
+};
 
+// Enum para status de retorno das operações
+enum class MonitorStatus {
+    SUCCESS,
+    FAILED,
+    BAD_MODE,
+    RESTART_REQUIRED,
+    MONITOR_NOT_FOUND
+};
 
-vector<MonitorInfo> EnumerateAllMonitors();
-bool ChangeResolution(const wstring& deviceName, int width, int height);
-bool SetPrimaryMonitor(const wstring& deviceName);
+// Declaração das funções que serão implementadas em MonitorUtils.cpp
+std::vector<MonitorInfo> EnumerateAllMonitors();
+MonitorStatus ChangeResolution(const std::wstring& deviceName, int width, int height);
+MonitorStatus SetPrimaryMonitor(const std::wstring& deviceName);
 
 #endif // MONITORUTILS_H

--- a/src/ConsoleUI.cpp
+++ b/src/ConsoleUI.cpp
@@ -1,0 +1,90 @@
+﻿#define NOMINMAX
+
+#include "ConsoleUI.h"
+#include <iostream>
+#include <limits>   // <--- CORREÇÃO PRINCIPAL: Incluído para std::numeric_limits
+#include <fcntl.h>  // Para _O_U16TEXT
+#include <io.h>     // Para _setmode
+#include <stdlib.h> // Para system("cls")
+
+using namespace std;
+
+void ConsoleUI::setupConsole() {
+    // Configura o console para aceitar caracteres Unicode (acentos, emojis)
+    _setmode(_fileno(stdout), _O_U16TEXT);
+    _setmode(_fileno(stdin), _O_U16TEXT);
+}
+
+void ConsoleUI::printMonitorInfo(const vector<MonitorInfo>& monitors) {
+    wcout << L"🖥️  Informações dos Monitores Atuais:" << endl;
+    for (size_t i = 0; i < monitors.size(); ++i) {
+        wcout << L"  " << i + 1 << L". Device: " << monitors[i].deviceName
+            << L", Resolução: " << monitors[i].width << L"x" << monitors[i].height;
+        if (monitors[i].isPrimary) {
+            wcout << L" (⭐ Primário)";
+        }
+        wcout << endl;
+    }
+    wcout << endl;
+}
+
+int ConsoleUI::displayMainMenu() {
+    wcout << L"Escolha uma opção:" << endl;
+    wcout << L"1. Mudar para 4K (3840x2160)" << endl;
+    wcout << L"2. Mudar para Full HD (1920x1080)" << endl;
+    wcout << L"3. Definir como monitor primário" << endl;
+    wcout << L"4. Sair" << endl;
+    wcout << L"Opção: ";
+
+    int option;
+    wcin >> option;
+    return option;
+}
+
+int ConsoleUI::selectMonitor(const vector<MonitorInfo>& monitors) {
+    wcout << L"\nEscolha o monitor para aplicar a alteração (1-" << monitors.size() << L"): ";
+    int monitorNum;
+    wcin >> monitorNum;
+
+    if (wcin.fail() || monitorNum <= 0 || monitorNum > monitors.size()) {
+        wcin.clear(); // Limpa o estado de erro
+        wcin.ignore(numeric_limits<streamsize>::max(), '\n'); // Descarta entrada inválida
+        return -1; // Indica seleção inválida
+    }
+    return monitorNum;
+}
+
+void ConsoleUI::showOperationResult(MonitorStatus status) {
+    switch (status) {
+    case MonitorStatus::SUCCESS:
+        wcout << L"\n✅ Operação realizada com sucesso!" << endl;
+        break;
+    case MonitorStatus::FAILED:
+        wcout << L"\n❌ Falha ao executar a operação." << endl;
+        break;
+    case MonitorStatus::BAD_MODE:
+        wcout << L"\n⚠️ O modo de vídeo não é suportado por este monitor." << endl;
+        break;
+    case MonitorStatus::RESTART_REQUIRED:
+        wcout << L"\n🔄 É necessário reiniciar o computador para aplicar as alterações." << endl;
+        break;
+    case MonitorStatus::MONITOR_NOT_FOUND:
+        wcout << L"\n🔍 Monitor não encontrado." << endl;
+        break;
+    }
+}
+
+void ConsoleUI::waitAndClear() {
+    wcout << L"\nPressione ENTER para continuar..." << endl;
+
+    // Se a última operação foi uma leitura de número (wcin >> ...),
+    // o caractere '\n' (Enter) ainda está no buffer.
+    // O primeiro ignore() limpa esse e quaisquer outros caracteres restantes.
+    wcin.ignore(numeric_limits<streamsize>::max(), '\n');
+
+    // Agora o programa espera por uma nova entrada, que será apenas o usuário pressionando Enter.
+    wcin.get();
+
+    // Limpa a tela do console
+    system("cls");
+}

--- a/src/MonitorUtils.cpp
+++ b/src/MonitorUtils.cpp
@@ -1,16 +1,10 @@
 #define UNICODE
 #define _UNICODE
-#include "include/MonitorUtils.h"
+#include "MonitorUtils.h"
 #include <windows.h>
-#include <wingdi.h>
-#include <iostream>
-#include <vector>
-#include <string>
 
-using namespace std;
-
-vector<MonitorInfo> EnumerateAllMonitors() {
-    vector<MonitorInfo> monitors;
+std::vector<MonitorInfo> EnumerateAllMonitors() {
+    std::vector<MonitorInfo> monitors;
     DISPLAY_DEVICEW dd = { sizeof(DISPLAY_DEVICEW), {0} };
     DWORD deviceNum = 0;
 
@@ -26,7 +20,8 @@ vector<MonitorInfo> EnumerateAllMonitors() {
             if (EnumDisplaySettingsW(dd.DeviceName, ENUM_CURRENT_SETTINGS, &dm)) {
                 info.width = dm.dmPelsWidth;
                 info.height = dm.dmPelsHeight;
-            } else {
+            }
+            else {
                 info.width = -1;
                 info.height = -1;
             }
@@ -37,172 +32,55 @@ vector<MonitorInfo> EnumerateAllMonitors() {
     return monitors;
 }
 
-bool ChangeResolution(const wstring& deviceName, int width, int height) {
-    // Primeiro, liberar as configurações atuais
-    ChangeDisplaySettingsExW(nullptr, nullptr, nullptr, 0, nullptr);
-
+MonitorStatus ChangeResolution(const std::wstring& deviceName, int width, int height) {
     DEVMODEW dm = { 0 };
     dm.dmSize = sizeof(DEVMODEW);
 
-    // Pegar as configurações atuais
     if (!EnumDisplaySettingsW(deviceName.c_str(), ENUM_CURRENT_SETTINGS, &dm)) {
-        wcout << L"Falha ao obter as configurações de exibição. Erro: " << GetLastError() << endl;
-        return false;
+        return MonitorStatus::FAILED;
     }
 
-    // Guardar configurações atuais
-    int currentWidth = dm.dmPelsWidth;
-    int currentHeight = dm.dmPelsHeight;
-    int currentFrequency = dm.dmDisplayFrequency;
-    int currentBitsPerPel = dm.dmBitsPerPel;
-
-    // Se já estiver na resolução desejada, tentar uma resolução intermediária primeiro
-    if (currentWidth == width && currentHeight == height) {
-        // Usar uma resolução intermediária (por exemplo, 1280x720)
-        dm.dmPelsWidth = 1280;
-        dm.dmPelsHeight = 720;
-        dm.dmDisplayFrequency = currentFrequency;
-        dm.dmBitsPerPel = currentBitsPerPel;
-        dm.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY | DM_BITSPERPEL;
-
-        LONG intermediateResult = ChangeDisplaySettingsExW(
-            deviceName.c_str(),
-            &dm,
-            nullptr,
-            CDS_UPDATEREGISTRY | CDS_GLOBAL,
-            nullptr
-        );
-
-        // Pequena pausa para garantir que a mudança seja processada
-        Sleep(1000);
-    }
-
-    // Configurar para a resolução desejada
     dm.dmPelsWidth = width;
     dm.dmPelsHeight = height;
-    dm.dmDisplayFrequency = currentFrequency;
-    dm.dmBitsPerPel = currentBitsPerPel;
-    dm.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT | DM_DISPLAYFREQUENCY | DM_BITSPERPEL;
+    dm.dmFields = DM_PELSWIDTH | DM_PELSHEIGHT;
 
     LONG result = ChangeDisplaySettingsExW(
-        deviceName.c_str(),
-        &dm,
-        nullptr,
-        CDS_UPDATEREGISTRY | CDS_GLOBAL,
-        nullptr
+        deviceName.c_str(), &dm, nullptr, CDS_UPDATEREGISTRY | CDS_GLOBAL, nullptr
     );
 
     switch (result) {
     case DISP_CHANGE_SUCCESSFUL:
-        wcout << L"Resolução alterada com sucesso para " << width << L"x" << height
-              << L" @ " << dm.dmDisplayFrequency << L"Hz" << endl;
-        return true;
-
+        return MonitorStatus::SUCCESS;
     case DISP_CHANGE_BADMODE:
-        {
-            DEVMODEW testDm = { 0 };
-            testDm.dmSize = sizeof(DEVMODEW);
-            int modeNum = 0;
-            bool foundMode = false;
-
-            while (EnumDisplaySettingsW(deviceName.c_str(), modeNum, &testDm)) {
-                if (testDm.dmPelsWidth == width &&
-                    testDm.dmPelsHeight == height) {
-
-                    dm.dmDisplayFrequency = testDm.dmDisplayFrequency;
-                    dm.dmBitsPerPel = testDm.dmBitsPerPel;
-
-                    result = ChangeDisplaySettingsExW(
-                        deviceName.c_str(),
-                        &dm,
-                        nullptr,
-                        CDS_UPDATEREGISTRY | CDS_GLOBAL,
-                        nullptr
-                    );
-
-                    if (result == DISP_CHANGE_SUCCESSFUL) {
-                        wcout << L"Resolução alterada com sucesso para " << width << L"x" << height
-                              << L" @ " << dm.dmDisplayFrequency << L"Hz" << endl;
-                        return true;
-                    }
-                }
-                modeNum++;
-            }
-            wcout << L"Não foi possível encontrar um modo compatível." << endl;
-        }
-        break;
-
-    case DISP_CHANGE_FAILED:
-        wcout << L"Falha ao alterar as configurações de exibição." << endl;
-        break;
-
+        return MonitorStatus::BAD_MODE;
     case DISP_CHANGE_RESTART:
-        wcout << L"Reinicialização necessária para aplicar as alterações." << endl;
-        break;
-
+        return MonitorStatus::RESTART_REQUIRED;
     default:
-        wcout << L"Erro desconhecido ao mudar a resolução. Código: " << result << endl;
+        return MonitorStatus::FAILED;
     }
-
-    dm.dmPelsWidth = currentWidth;
-    dm.dmPelsHeight = currentHeight;
-    dm.dmDisplayFrequency = currentFrequency;
-    dm.dmBitsPerPel = currentBitsPerPel;
-
-    ChangeDisplaySettingsExW(
-        deviceName.c_str(),
-        &dm,
-        nullptr,
-        CDS_UPDATEREGISTRY | CDS_GLOBAL,
-        nullptr
-    );
-
-    return false;
 }
 
-bool SetPrimaryMonitor(const wstring& deviceName) {
-    DISPLAY_DEVICEW dd = { sizeof(DISPLAY_DEVICEW), {0} };
-    DWORD deviceNum = 0;
-    bool foundTarget = false;
-
-    // Encontrar o monitor alvo
-    while (EnumDisplayDevicesW(nullptr, deviceNum, &dd, 0)) {
-        if (wcscmp(dd.DeviceName, deviceName.c_str()) == 0) {
-            foundTarget = true;
-            break;
-        }
-        deviceNum++;
+MonitorStatus SetPrimaryMonitor(const std::wstring& deviceName) {
+    DEVMODEW dm = { 0 };
+    dm.dmSize = sizeof(DEVMODEW);
+    if (!EnumDisplaySettingsW(deviceName.c_str(), ENUM_CURRENT_SETTINGS, &dm)) {
+        return MonitorStatus::MONITOR_NOT_FOUND;
     }
 
-    if (!foundTarget) {
-        wcout << L"Monitor não encontrado!" << endl;
-        return false;
-    }
+    dm.dmPosition.x = 0;
+    dm.dmPosition.y = 0;
+    dm.dmFields = DM_POSITION;
 
-    // Obter as configurações atuais do monitor alvo
-    DEVMODEW dmNew = { 0 };
-    dmNew.dmSize = sizeof(DEVMODEW);
-    if (!EnumDisplaySettingsW(deviceName.c_str(), ENUM_CURRENT_SETTINGS, &dmNew)) {
-        wcout << L"Falha ao obter configurações do monitor." << endl;
-        return false;
-    }
+    LONG result = ChangeDisplaySettingsExW(
+        deviceName.c_str(), &dm, nullptr, CDS_UPDATEREGISTRY | CDS_SET_PRIMARY, nullptr
+    );
 
-    // Manter a posição e definir como primário
-    dmNew.dmFields = DM_POSITION | DM_PELSWIDTH | DM_PELSHEIGHT;
-    dmNew.dmPosition.x = 0;
-    dmNew.dmPosition.y = 0;
-
-    LONG res = ChangeDisplaySettingsExW(deviceName.c_str(), &dmNew, nullptr, CDS_UPDATEREGISTRY | CDS_GLOBAL, nullptr);
-    if (res == DISP_CHANGE_SUCCESSFUL) {
-        wcout << L"Monitor alterado para primário com sucesso!" << endl;
-
-        // Reiniciar o Explorer para garantir que o Windows reconheça a mudança
-        system("taskkill /f /im explorer.exe");
+    if (result == DISP_CHANGE_SUCCESSFUL) {
+        // Reiniciar o Explorer para garantir que a barra de tarefas e ícones se atualizem corretamente
+        system("taskkill /f /im explorer.exe > nul 2>&1");
         system("start explorer.exe");
-
-        return true;
-    } else {
-        wcout << L"Falha ao definir monitor primário. Código de erro: " << res << endl;
-        return false;
+        return MonitorStatus::SUCCESS;
     }
+
+    return MonitorStatus::FAILED;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,88 +1,51 @@
-#include "include/MonitorUtils.h"
+#include "MonitorUtils.h"
+#include "ConsoleUI.h"
 #include <iostream>
-#include <string>
-#include <thread>
-#include <chrono>
-#include <fcntl.h>  // para _O_U16TEXT
-#include <io.h>     // para _setmode
-
-using namespace std;
-
-void printMonitorInfo(const vector<MonitorInfo>& monitors) {
-    wcout << L"\nInformações dos Monitores:" << endl;
-    for (const auto& monitor : monitors) {
-        wcout << L"Device: " << monitor.deviceName
-              << L", Resolucao: " << monitor.width << L"x" << monitor.height;
-        if (monitor.isPrimary) {
-            wcout << L" (Primario)" << endl;
-        } else {
-            wcout << L" (Secundario)" << endl;
-        }
-    }
-    wcout << endl;
-}
+#include <vector>
 
 int main() {
-    // Configurar console para Unicode
-    _setmode(_fileno(stdout), _O_U16TEXT);
-    _setmode(_fileno(stdin), _O_U16TEXT);
+    ConsoleUI::setupConsole();
 
     while (true) {
-        // Listar monitores e suas configurações atuais
-        vector<MonitorInfo> monitors = EnumerateAllMonitors();
-        printMonitorInfo(monitors);
+        std::vector<MonitorInfo> monitors = EnumerateAllMonitors();
+        ConsoleUI::printMonitorInfo(monitors);
 
-        // Menu de opções
-        wcout << L"Escolha uma opção:" << endl;
-        wcout << L"1. Mudar para 4K (3840x2160)" << endl;
-        wcout << L"2. Mudar para Full HD (1920x1080)" << endl;
-        wcout << L"3. Alternar monitor primário" << endl;
-        wcout << L"4. Sair" << endl;
-        wcout << L"Opção: ";
+        int option = ConsoleUI::displayMainMenu();
 
-        int opcao;
-        wcin >> opcao;
-
-        if (opcao == 4) break;
-
-        // Selecionar monitor
-        wcout << L"\nEscolha o monitor (1 para DISPLAY1, 2 para DISPLAY2, etc): ";
-        int monitorNum;
-        wcin >> monitorNum;
-
-        if (monitorNum <= 0 || monitorNum > monitors.size()) {
-            wcout << L"Monitor inválido!" << endl;
-            continue;
+        if (option == 4) {
+            break; // Sai do loop e encerra o programa
         }
 
-        const wstring targetDevice = monitors[monitorNum - 1].deviceName;
-
-        switch (opcao) {
-            case 1: // 4K
-                if (ChangeResolution(targetDevice, 3840, 2160)) {
-                    wcout << L"Resolução alterada para 4K com sucesso!" << endl;
-                }
-                break;
-
-            case 2: // Full HD
-                if (ChangeResolution(targetDevice, 1920, 1080)) {
-                    wcout << L"Resolução alterada para Full HD com sucesso!" << endl;
-                }
-                break;
-
-            case 3: // Alternar primário
-                if (SetPrimaryMonitor(targetDevice)) {
-                    wcout << L"Monitor configurado como primário com sucesso!" << endl;
-                }
-                break;
-
-            default:
-                wcout << L"Opção inválida!" << endl;
+        if (option < 1 || option > 3 || monitors.empty()) {
+            std::wcout << L"\nOpção inválida ou nenhum monitor encontrado." << std::endl;
+            ConsoleUI::waitAndClear();
+            continue; // Volta para o início do loop
         }
 
-        // Pequena pausa para ver o resultado
-        wcout << L"\nAguarde..." << endl;
-        this_thread::sleep_for(chrono::seconds(2));
+        int monitorNum = ConsoleUI::selectMonitor(monitors);
+        if (monitorNum == -1) {
+            std::wcout << L"\nSeleção de monitor inválida!" << std::endl;
+            ConsoleUI::waitAndClear();
+            continue; // Volta para o início do loop
+        }
+
+        const std::wstring& targetDevice = monitors[monitorNum - 1].deviceName;
+        MonitorStatus status;
+
+        switch (option) {
+        case 1: // 4K
+            status = ChangeResolution(targetDevice, 3840, 2160);
+            break;
+        case 2: // Full HD
+            status = ChangeResolution(targetDevice, 1920, 1080);
+            break;
+        case 3: // Alternar primário
+            status = SetPrimaryMonitor(targetDevice);
+            break;
+        }
+
+        ConsoleUI::showOperationResult(status);
+        ConsoleUI::waitAndClear();
     }
 
     return 0;


### PR DESCRIPTION
Introduced a dedicated module to handle all user interactions. such as printing menus and reading input.

- Moved all console I/O (wcout, wcin) from main.cpp and MonitorUtils.cpp into the new ConsolueUI class .
- Modified MonitorUtils functions (e.g., ChangeResolution) to return a MonitorStatus enum instead of printing directly to the console.
- Simplified main.cpp to act as an orchestrator, delegating calls to ConsoleUI and MonitorUtils.

This significantly improves separation of concerns, making the code more modular, testable, and easier to maintain.